### PR TITLE
refactor: 카카오 로그인 실패시 ui수정

### DIFF
--- a/src/client/hooks/page/useKakaoLoginCallback.ts
+++ b/src/client/hooks/page/useKakaoLoginCallback.ts
@@ -1,21 +1,19 @@
 import { useEffect } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
-import ROUTES from '@constants/routes';
+import { useSearchParams } from 'react-router-dom';
 import { kakaoLogin } from '@services/auth';
 import { KakaoMemberRole } from '@typings/member';
 import useAuth from '@hooks/auth/useAuth';
 
-const useKakaoLoginCallback = () => {
+const useKakaoLoginCallback = (onError: (message: string) => void) => {
   const [searchParams] = useSearchParams();
   const { setCurrentMember } = useAuth();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const code = searchParams.get('code');
     const role = searchParams.get('role') as KakaoMemberRole;
 
     if (!code || !role) {
-      navigate(ROUTES.logIn);
+      onError('잘못된 접근입니다.');
       return;
     }
 
@@ -27,12 +25,12 @@ const useKakaoLoginCallback = () => {
         setCurrentMember(accessToken, memberRole, '');
       } catch (error) {
         console.log(error);
-        navigate(ROUTES.logIn);
+        onError('로그인에 실패했습니다.');
       }
     };
 
     login();
-  }, [searchParams, navigate]);
+  }, [searchParams]);
 };
 
 export default useKakaoLoginCallback;

--- a/src/client/pages/KakaoLoginCallback.tsx
+++ b/src/client/pages/KakaoLoginCallback.tsx
@@ -1,10 +1,38 @@
-import LoadingPage from './LoadingPage';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Modal from '@shared/components/common/Modal';
+import useError from '@shared/hooks/ui/useError';
 import useKakaoLoginCallback from '@hooks/page/useKakaoLoginCallback';
+import LoadingPage from './LoadingPage';
+import ROUTES from '@constants/routes';
 
 const KakaoLoginCallback = () => {
-  useKakaoLoginCallback();
+  const { error, updateError, resetError } = useError();
+  const navigate = useNavigate();
+  const onKakaoLoginError = useCallback((message: string) => {
+    updateError(message);
+  }, []);
+  const handleCloseErrorModal = () => {
+    resetError();
+    navigate(ROUTES.logIn);
+  };
 
-  return <LoadingPage />;
+  useKakaoLoginCallback(onKakaoLoginError);
+
+  return (
+    <>
+      <LoadingPage />
+      <Modal
+        variant="centered"
+        closeType="none"
+        isOpen={!!error}
+        role="alert"
+        onClose={handleCloseErrorModal}
+      >
+        {error}
+      </Modal>
+    </>
+  );
 };
 
 export default KakaoLoginCallback;


### PR DESCRIPTION
### ⛳ 이슈 번호
Fixes #271 

### 🛠️ 작업 내용 (What)
* 카카오 로그인 실패시 모달 렌더링
* 모달 confirm시 로그인 페이지로 리다이렉트