### PR TITLE
fix: 로그아웃시 홈 이동 로직 수정, 공지사항 목록 조회 응답값 타입 수정

### DIFF
--- a/src/admin/pages/notices/NoticeList/index.tsx
+++ b/src/admin/pages/notices/NoticeList/index.tsx
@@ -10,7 +10,7 @@ import { SNoticeItem } from './styles';
 const NoticeList = () => {
   const currentPage = usePageParam();
   const { data, isLoading, isError } = useNoticeList(currentPage);
-  const { data: content, totalElements, size } = data || {};
+  const { content, totalElements, size } = data || {};
   const onClickPagination = usePaginationNavigator(ROUTES.notices.root);
 
   const navigate = useNavigate();

--- a/src/client/hooks/auth/useLogout.ts
+++ b/src/client/hooks/auth/useLogout.ts
@@ -16,7 +16,7 @@ const useLogout = () => {
       await authServices.logout();
       removeMember();
       invalidateAllQueries();
-      navigate(ROUTES.home, { replace: true });
+      // navigate(ROUTES.home, { replace: true });
     } catch (error) {
       console.log(error);
     }

--- a/src/shared/typings/response/noticesResponse.ts
+++ b/src/shared/typings/response/noticesResponse.ts
@@ -2,7 +2,7 @@ import { Notice, NoticeDetail } from '../notices';
 
 interface NoticesResponse {
   code: number;
-  data: Notice[];
+  content: Notice[];
   page: number;
   size: number;
   totalElements: number;


### PR DESCRIPTION
### 🛠️ 작업 내용 (What)
* 로그아웃시 명시적으로 홈으로 navigate 하던 부분 삭제
* 공지사항 목록 조회 응답값 타입의 속성명 수정