### PR TITLE
fix: 일반 유저 반려동물 정보 등록시 홈 추천 숙소 리스트 invalidate

### DIFF
--- a/src/client/hooks/page/useUserMyPet.ts
+++ b/src/client/hooks/page/useUserMyPet.ts
@@ -5,6 +5,7 @@ import useIsLoading from '@shared/hooks/ui/useIsLoading';
 import useError from '@shared/hooks/ui/useError';
 import { PetInfo } from '@typings/pet';
 import { deleteMyPet } from '@services/pet';
+import useUserPetRecommendations from '@hooks/query/user/useUserPetRecommendations';
 
 const useUserMyPet = () => {
   const { data, error, isLoading, refreshMyPetList } = useMyPetList();
@@ -26,6 +27,7 @@ const useUserMyPet = () => {
     startIsLoading: startDeleteLoading,
     endIsLoading: endDeleteLoading,
   } = useIsLoading();
+  const { invalidateUserPetRecommendations } = useUserPetRecommendations(false);
 
   const resetSelectedPet = () => {
     if (selectedPet) setSelectedPet(null);
@@ -66,6 +68,7 @@ const useUserMyPet = () => {
     closeForm();
     resetSelectedPet();
     refreshMyPetList();
+    invalidateUserPetRecommendations();
   }, [resetSelectedPet]);
 
   return {

--- a/src/client/hooks/query/user/useUserPetRecommendations.ts
+++ b/src/client/hooks/query/user/useUserPetRecommendations.ts
@@ -2,18 +2,21 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getUserPetRecommendations } from '@services/recommendations';
 import { UserPetRecommendationsResponse } from '@typings/response/recommendations';
 
-const useUserPetRecommendations = () => {
+const useUserPetRecommendations = (enabled: boolean = true) => {
+  const QUERY_KEY = 'user-pet-recommendations' as const;
+
   const result = useQuery({
-    queryKey: ['user-pet-recommendations'],
+    queryKey: [QUERY_KEY],
     queryFn: () => getUserPetRecommendations(),
     staleTime: 1000 * 60 * 60,
+    enabled,
   });
 
   const queryClient = useQueryClient();
 
   const refresehUserPetRecommendations = (accommodationId: number) => {
     const prev = queryClient.getQueryData<UserPetRecommendationsResponse>([
-      'user-pet-recommendations',
+      QUERY_KEY,
     ]);
     if (!prev) return;
     const newData = prev.map((v) => {
@@ -32,10 +35,18 @@ const useUserPetRecommendations = () => {
       }
       return v;
     });
-    queryClient.setQueryData(['user-pet-recommendations'], newData);
+    queryClient.setQueryData([QUERY_KEY], newData);
   };
 
-  return { ...result, refresehUserPetRecommendations };
+  const invalidateUserPetRecommendations = async () => {
+    await queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+  };
+
+  return {
+    ...result,
+    refresehUserPetRecommendations,
+    invalidateUserPetRecommendations,
+  };
 };
 
 export default useUserPetRecommendations;

--- a/src/client/pages/Home/UserRecommendations/MostViewedRecommendations.tsx
+++ b/src/client/pages/Home/UserRecommendations/MostViewedRecommendations.tsx
@@ -14,7 +14,7 @@ const MostViewedRecommendations = () => {
   const { data, isLoading, error, refreshMostViewedRecommendations } =
     useMostViewedRecommendations();
   const { refreshWishlist } = useWishlist(0, false);
-  const { refresehUserPetRecommendations } = useUserPetRecommendations();
+  const { refresehUserPetRecommendations } = useUserPetRecommendations(false);
 
   const onSuccessClickWishButton = (accommodationId: number) => {
     setList((prev) => {

--- a/src/client/pages/user/UserMyPet/UserMyPetModals.tsx
+++ b/src/client/pages/user/UserMyPet/UserMyPetModals.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import Modal from '@shared/components/common/Modal';
 import Button from '@shared/components/common/Button';
 import { SDeleteConfirmation } from './styles';
@@ -79,4 +80,4 @@ const UserMyPetModals = ({
   );
 };
 
-export default UserMyPetModals;
+export default memo(UserMyPetModals);


### PR DESCRIPTION
### 🛠️ 작업 내용 (What)
* useUserPetRecommendations 에 쿼리 invalidate 함수 추가
* 유저가 반려동물 정보 등록/수정시 홈 화면의 반려동물별 추천 숙소 목록 invalidate
