### PR TITLE
fix: 아임포트 sdk에 buyer_email 항목 빈 문자열로 전달

### DIFF
--- a/src/client/pages/Accommodation/Reservation.tsx
+++ b/src/client/pages/Accommodation/Reservation.tsx
@@ -141,6 +141,7 @@ const Reservation = () => {
         amount: adjustedTotalPrice,
         buyer_name: reserverName,
         buyer_tel: reserverPhoneNumber,
+        buyer_email: '',
       });
 
       if (res.success && res.imp_uid && res.merchant_uid) {


### PR DESCRIPTION
### 🛠️ 작업 내용 (What)
* 결제진행시 아임포트 sdk에 buyer_email 항목 빈 문자열로 전달